### PR TITLE
Pretty-print headers (v0); tests pass

### DIFF
--- a/ELFSage/Commands/Read.lean
+++ b/ELFSage/Commands/Read.lean
@@ -1,8 +1,5 @@
 import Cli
 import ELFSage.Util.Cli
-import ELFSage.Util.Flags
-import ELFSage.Util.Hex
-import ELFSage.Util.List
 import ELFSage.Types.File
 import ELFSage.Types.ELFHeader
 import ELFSage.Types.ProgramHeaderTable
@@ -13,9 +10,6 @@ import ELFSage.Types.StringTable
 import ELFSage.Types.Dynamic
 import ELFSage.Types.Note
 import ELFSage.Types.Relocation
-
-open Hex
-open Flags
 
 def checkImplemented (p: Cli.Parsed) : Except String Unit := do
   let unimplemented :=
@@ -43,55 +37,8 @@ def checkImplemented (p: Cli.Parsed) : Except String Unit := do
 def printFileHeader (eh : RawELFHeader) := do
   IO.println $ toString eh
 
-private def getProgramHeaderType (n: Nat) := match n with
-  -- TODO: Finish populating this list of magic numbers, it is incomplete.
-  | 1           => "PT_LOAD"          -- (0x1)
-  | 2           => "PT_DYNAMIC"       -- (0x2)
-  | 3           => "PT_INTERP"        -- (0x3)
-  | 4           => "PT_NOTE"          -- (0x4)
-  | 6           => "PT_PHDR"          -- (0x6)
-  | 1685382480  => "PT_GNU_EH_FRAME"  -- (0x6474E550)
-  | 1685382481  => "PT_GNU_STACK"     -- (0x6474E551)
-  | 1685382482  => "PT_GNU_RELRO"     -- (0x6474E552)
-  | 1685382483  => "PT_GNU_PROPERTY"  -- (0x6474E553)
-  | _ => panic s!"Unrecognized program header type {n}"
-
-private def getProgramHeaderFlag (flagIndex: Nat) := match flagIndex with
-  -- TODO: Finish populating this list of magic numbers, it is incomplete.
-  | 0  => "PF_X"  -- (0x1)
-  | 1  => "PF_W"  -- (0x2)
-  | 2  => "PF_R"  -- (0x4)
-  | _ => panic s!"Unrecognized program header flag {flagIndex}"
-
-private def programHeaderFlagsToString (flags: Nat) (indent: String) : String :=
-  getFlagBits flags 32
-    |> .map (λ flag => s!"{indent}{getProgramHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
-    |> List.insertionSort (. < .) -- sort by flag name
-    |> String.join
-
 def printProgramHeaders (elffile : RawELFFile) := do
-  let mut out := "ProgramHeaders [\n"
-  let headers := elffile.getRawProgramHeaderTableEntries
-  let mut idx := 0
-  for ⟨phte, _⟩ in headers do
-    let nextHeader :=
-        "  ProgramHeader {\n" ++
-      s!"    Type: {getProgramHeaderType $ ProgramHeaderTableEntry.p_type phte} (0x{toHex $ ProgramHeaderTableEntry.p_type phte})\n" ++
-      s!"    Offset: 0x{toHex $ ProgramHeaderTableEntry.p_offset phte}\n" ++
-      s!"    VirtualAddress: 0x{toHex $ ProgramHeaderTableEntry.p_vaddr phte}\n" ++
-      s!"    PhysicalAddress: 0x{toHex $ ProgramHeaderTableEntry.p_paddr phte}\n" ++
-      s!"    FileSize: {ProgramHeaderTableEntry.p_filesz phte}\n" ++
-      s!"    MemSize: {ProgramHeaderTableEntry.p_memsz phte}\n" ++
-      s!"    Flags [ (0x{toHex $ ProgramHeaderTableEntry.p_flags phte})\n" ++
-      s!"{     programHeaderFlagsToString (ProgramHeaderTableEntry.p_flags phte) "      "}" ++
-        "    ]\n" ++
-      s!"    Alignment: {ProgramHeaderTableEntry.p_align phte}\n" ++
-        "  }\n"
-    out := out ++ nextHeader
-    idx := idx + 1
-
-  out := out ++ "]"
-  IO.println out
+  IO.println $ RawELFFile.programHeadersToString elffile
 
 def symbolNameByLinkAndOffset
   (elffile : RawELFFile)
@@ -104,65 +51,8 @@ def symbolNameByLinkAndOffset
     let stringtable : ELFStringTable := ⟨sec.section_body⟩
     pure $ stringtable.stringAt offset
 
-private def getSectionHeaderType (n: Nat) := match n with
-  -- TODO: Finish populating this list of magic numbers, it is incomplete.
-  | 0           => "SHT_NULL"         -- (0x0)
-  | 1           => "SHT_PROGBITS"     -- (0x1)
-  | 3           => "SHT_STRTAB"       -- (0x3)
-  | 4           => "SHT_RELA"         -- (0x4)
-  | 6           => "SHT_DYNAMIC"      -- (0x6)
-  | 7           => "SHT_NOTE"         -- (0x7)
-  | 8           => "SHT_NOBITS"       -- (0x8)
-  | 11          => "SHT_DYNSYM"       -- (0xB)
-  | 14          => "SHT_INIT_ARRAY"   -- (0xE)
-  | 15          => "SHT_FINI_ARRAY"   -- (0xF)
-  | 1879048182  => "SHT_GNU_HASH"     -- (0x6FFFFFF6)
-  | 1879048190  => "SHT_GNU_verneed"  -- (0x6FFFFFFE)
-  | 1879048191  => "SHT_GNU_versym"   -- (0x6FFFFFFF)
-  | _ => panic s!"Unrecognized section header type {n}"
-
-private def getSectionHeaderFlag (flagIndex: Nat) := match flagIndex with
-  -- TODO: Finish populating this list of magic numbers, it is incomplete.
-  | 0  => "SHF_WRITE"      -- (0x1)
-  | 1  => "SHF_ALLOC"      -- (0x2)
-  | 2  => "SHF_EXECINSTR"  -- (0x4)
-  | 4  => "SHF_MERGE"      -- (0x10)
-  | 5  => "SHF_STRINGS"    -- (0x20)
-  | _ => panic s!"Unrecognized section header flag {flagIndex}"
-
-private def sectionHeaderFlagsToString (flags: Nat) (indent: String) : String :=
-  getFlagBits flags 64
-    |> .map (λ flag => s!"{indent}{getSectionHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
-    |> List.insertionSort (. < .) -- sort by flag name
-    |> String.join
-
 def printSectionHeaders (elffile : RawELFFile) := do
-  let mut out := "Sections [\n"
-  let headers := elffile.getRawSectionHeaderTableEntries
-  let mut idx := 0
-  for ⟨phte, sec⟩ in headers do
-    let name := match sec.section_name_as_string with | .some s => s | _ => ""
-    let nextHeader :=
-        "  Section {\n" ++
-      s!"    Index: {idx}\n" ++
-      s!"    Name: {name} ({SectionHeaderTableEntry.sh_name phte})\n" ++
-      s!"    Type: {getSectionHeaderType $ SectionHeaderTableEntry.sh_type phte} (0x{toHex $ SectionHeaderTableEntry.sh_type phte})\n" ++
-      s!"    Flags [ (0x{toHex $ SectionHeaderTableEntry.sh_flags phte})\n" ++
-      s!"{     sectionHeaderFlagsToString (SectionHeaderTableEntry.sh_flags phte) "      "}" ++
-        "    ]\n" ++
-      s!"    Address: 0x{toHex $ SectionHeaderTableEntry.sh_addr phte}\n" ++
-      s!"    Offset: 0x{toHex $ SectionHeaderTableEntry.sh_offset phte}\n" ++
-      s!"    Size: {SectionHeaderTableEntry.sh_size phte}\n" ++
-      s!"    Link: {SectionHeaderTableEntry.sh_link phte}\n" ++
-      s!"    Info: {SectionHeaderTableEntry.sh_info phte}\n" ++
-      s!"    AddressAlignment: {SectionHeaderTableEntry.sh_addralign phte}\n" ++
-      s!"    EntrySize: {SectionHeaderTableEntry.sh_entsize phte}\n" ++
-        "  }\n"
-    out := out ++ nextHeader
-    idx := idx + 1
-
-  out := out ++ "]"
-  IO.println out
+  IO.println $ RawELFFile.sectionHeadersToString elffile
 
 def printHeaders (elffile : RawELFFile) := do
   printFileHeader elffile.getRawELFHeader

--- a/ELFSage/Commands/Read.lean
+++ b/ELFSage/Commands/Read.lean
@@ -34,6 +34,9 @@ def checkImplemented (p: Cli.Parsed) : Except String Unit := do
 
   return ()
 
+def printFileHeader (eh : RawELFHeader) := do
+  IO.println $ toString eh
+
 def printProgramHeaders (ef : RawELFFile) := do
   let headers := ef.getRawProgramHeaderTableEntries
   let mut idx := 0
@@ -63,7 +66,7 @@ def printSectionHeaders (elffile : RawELFFile) := do
     idx := idx + 1
 
 def printHeaders (elffile : RawELFFile) := do
-  IO.println $ repr elffile.getRawELFHeader
+  printFileHeader elffile.getRawELFHeader
   printProgramHeaders elffile
   printSectionHeaders elffile
 
@@ -240,7 +243,7 @@ def runReadCmd (p: Cli.Parsed): IO UInt32 := do
 
   for flag in p.flags do
     match flag.flag.longName with
-    | "file-header" => IO.println $ repr elfheader
+    | "file-header" => printFileHeader elfheader
     | "headers" => printHeaders elffile
     | "program-headers" => printProgramHeaders elffile
     | "segments" => printProgramHeaders elffile

--- a/ELFSage/Commands/Read.lean
+++ b/ELFSage/Commands/Read.lean
@@ -34,12 +34,6 @@ def checkImplemented (p: Cli.Parsed) : Except String Unit := do
 
   return ()
 
-def printFileHeader (eh : RawELFHeader) := do
-  IO.println $ toString eh
-
-def printProgramHeaders (elffile : RawELFFile) := do
-  IO.println $ RawELFFile.programHeadersToString elffile
-
 def symbolNameByLinkAndOffset
   (elffile : RawELFFile)
   (linkIdx: Nat)
@@ -50,14 +44,6 @@ def symbolNameByLinkAndOffset
   | .some ⟨_, sec⟩ =>
     let stringtable : ELFStringTable := ⟨sec.section_body⟩
     pure $ stringtable.stringAt offset
-
-def printSectionHeaders (elffile : RawELFFile) := do
-  IO.println $ RawELFFile.sectionHeadersToString elffile
-
-def printHeaders (elffile : RawELFFile) := do
-  printFileHeader elffile.getRawELFHeader
-  printSectionHeaders elffile
-  printProgramHeaders elffile
 
 /- Prints all the symbols in the section with header `sectionHeaderEnt` -/
 def printSymbolsForSection
@@ -210,6 +196,18 @@ def printRelocationSections (elffile: RawELFFile) :=
       | .some name => IO.print s!"Relocations from {name}\n"
       | .none => IO.print s!"Relocations from unnamed section\n"
       printRelocationA elffile shte sec
+
+private def printFileHeader (eh : RawELFHeader) := do
+  IO.println $ toString eh
+
+private def printSectionHeaders (elffile : RawELFFile) := do
+  IO.println $ RawELFFile.sectionHeadersToString elffile
+
+private def printProgramHeaders (elffile : RawELFFile) := do
+  IO.println $ RawELFFile.programHeadersToString elffile
+
+private def printHeaders (elffile : RawELFFile) := do
+  IO.println $ RawELFFile.headersToString elffile
 
 def runReadCmd (p: Cli.Parsed): IO UInt32 := do
 

--- a/ELFSage/Test/Data/PrintedHeaders/true
+++ b/ELFSage/Test/Data/PrintedHeaders/true
@@ -1,9 +1,3 @@
-
-File: ./ELFFiles/true
-Format: elf64-x86-64
-Arch: x86_64
-AddressSize: 64bit
-LoadName: <Not found>
 ElfHeader {
   Ident {
     Magic: (7F 45 4C 46)

--- a/ELFSage/Test/Data/generatePrintedOutputs.sh
+++ b/ELFSage/Test/Data/generatePrintedOutputs.sh
@@ -9,7 +9,8 @@ mkdir PrintedHeaders
 
 for f in ./ELFFiles/*; do
   fname=$(basename -- "$f")
-  llvm-readobj --headers ./ELFFiles/$fname > PrintedHeaders/$fname
+  # llvm-readobj prepends 6 lines of file metadata before all outputs. Discard this metadata
+  llvm-readobj --headers ./ELFFiles/$fname | tail -n +7 > PrintedHeaders/$fname
 done
 
 popd &> /dev/null

--- a/ELFSage/Types/ELFHeader.lean
+++ b/ELFSage/Types/ELFHeader.lean
@@ -1,5 +1,8 @@
 import ELFSage.Types.Sizes
 import ELFSage.Util.ByteArray
+import ELFSage.Util.Hex
+
+open Hex
 
 class ELFHeader (α : Type) where
   e_ident    : α → NByteArray 16
@@ -87,6 +90,64 @@ instance : ELFHeader ELF64Header where
   e_shnum eh      := eh.e_shnum.toNat
   e_shstrndx eh   := eh.e_shstrndx.toNat
 
+private def getHeaderClass (n: UInt8) : String := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 2 => "64-bit"
+  | _ => panic s!"Unrecognized header class {n}"
+
+private def getHeaderDataEncoding (n: UInt8) : String := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 1 => "LittleEndian"
+  | _ => panic s!"Unrecognized header data encoding {n}"
+
+private def getHeaderOS (n: UInt8) : String := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 0 => "SystemV"
+  | _ => panic s!"Unrecognized header OS/ABI {n}"
+
+private def getHeaderType (n: UInt16) : String := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 3 => "SharedObject"
+  | _ => panic s!"Unrecognized header type {n}"
+
+private def getHeaderMachine (n: UInt16) : String := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 62 => "EM_X86_64"
+  | _ => panic s!"Unrecognized header machine {n}"
+
+instance : ToString ELF64Header where toString eh :=
+  let ident (i : Fin 16) := eh.e_ident.bytes.get ⟨ i, by simp [eh.e_ident.sized] ⟩
+  let identAsHex (i: Fin 16) := toHex (ident i).toNat
+  let identAsHexLength2 (i: Fin 16) := toHexMinLength (ident i).toNat 2
+
+  let val :=
+    "ElfHeader {\n" ++
+    "  Ident {\n" ++
+  s!"    Magic: ({identAsHexLength2 0} {identAsHexLength2 1} {identAsHexLength2 2} {identAsHexLength2 3})\n" ++
+  s!"    Class: {getHeaderClass $ ident 4} (0x{identAsHex 4})\n" ++
+  s!"    DataEncoding: {getHeaderDataEncoding $ ident 5} (0x{identAsHex 5})\n" ++
+  s!"    FileVersion: {ident 6}\n" ++
+  s!"    OS/ABI: {getHeaderOS $ ident 7} (0x{identAsHex 7})\n" ++
+  s!"    ABIVersion: {ident 8}\n" ++
+  s!"    Unused: ({identAsHexLength2 9} {identAsHexLength2 10} {identAsHexLength2 11} {identAsHexLength2 12} {identAsHexLength2 13} {identAsHexLength2 14} {identAsHexLength2 15})\n" ++
+    "  }\n" ++
+  s!"  Type: {getHeaderType eh.e_type} (0x{toHex eh.e_type.toNat})\n" ++
+  s!"  Machine: {getHeaderMachine eh.e_machine} (0x{toHex eh.e_machine.toNat})\n" ++
+  s!"  Version: {eh.e_version}\n" ++
+  s!"  Entry: 0x{toHex eh.e_entry.toNat}\n" ++
+  s!"  ProgramHeaderOffset: 0x{toHex eh.e_phoff.toNat}\n" ++
+  s!"  SectionHeaderOffset: 0x{toHex eh.e_shoff.toNat}\n" ++
+  s!"  Flags [ (0x{toHex eh.e_flags.toNat})\n" ++
+    "  ]\n" ++
+  s!"  HeaderSize: {eh.e_ehsize}\n" ++
+  s!"  ProgramHeaderEntrySize: {eh.e_phentsize}\n" ++
+  s!"  ProgramHeaderCount: {eh.e_phnum}\n" ++
+  s!"  SectionHeaderEntrySize: {eh.e_shentsize}\n" ++
+  s!"  SectionHeaderCount: {eh.e_shnum}\n" ++
+  s!"  StringTableSectionIndex: {eh.e_shstrndx}\n" ++
+    "}"
+  val
+
 /-- A simple parser for extracting an ELF64 header, just a test, no validation -/
 def mkELF64Header (bs : ByteArray) (h : bs.size ≥ 0x40) : ELF64Header := { 
   e_ident     := NByteArray.extract bs 0x10 (by omega),
@@ -160,6 +221,8 @@ instance : ELFHeader ELF32Header where
   e_shnum eh      := eh.e_shnum.toNat
   e_shstrndx eh   := eh.e_shstrndx.toNat
 
+instance : ToString ELF32Header where toString eh := toString $ repr eh
+
 /-- A simple parser for extracting an ELF32 header, just a test, no validation -/
 def mkELF32Header (bs : ByteArray) (h : bs.size ≥ 0x34) : ELF32Header := { 
   e_ident     := NByteArray.extract bs 0x10 (by omega),
@@ -205,6 +268,11 @@ instance : ELFHeader RawELFHeader where
   e_shentsize eh  := match eh with | .elf64 eh => eh.e_shentsize.toNat | .elf32 eh => eh.e_shentsize.toNat
   e_shnum eh      := match eh with | .elf64 eh => eh.e_shnum.toNat     | .elf32 eh => eh.e_shnum.toNat
   e_shstrndx eh   := match eh with | .elf64 eh => eh.e_shstrndx.toNat  | .elf32 eh => eh.e_shstrndx.toNat
+
+instance : ToString RawELFHeader where toString eh :=
+  match eh with
+    | .elf32 eh => toString eh
+    | .elf64 eh => toString eh
 
 def mkRawELFHeader? (bs : ByteArray) : Except String RawELFHeader :=
   if h : bs.size < 5 then throw "Can't determine if this is a 32 or 64 bit binary (not enough bytes)."

--- a/ELFSage/Types/ELFHeader.lean
+++ b/ELFSage/Types/ELFHeader.lean
@@ -149,7 +149,7 @@ instance : ToString ELF64Header where toString eh :=
   val
 
 /-- A simple parser for extracting an ELF64 header, just a test, no validation -/
-def mkELF64Header (bs : ByteArray) (h : bs.size ≥ 0x40) : ELF64Header := { 
+def mkELF64Header (bs : ByteArray) (h : bs.size ≥ 0x40) : ELF64Header := {
   e_ident     := NByteArray.extract bs 0x10 (by omega),
   e_type      := getUInt16from 0x10 (by omega),
   e_machine   := getUInt16from 0x12 (by omega),
@@ -224,7 +224,7 @@ instance : ELFHeader ELF32Header where
 instance : ToString ELF32Header where toString eh := toString $ repr eh
 
 /-- A simple parser for extracting an ELF32 header, just a test, no validation -/
-def mkELF32Header (bs : ByteArray) (h : bs.size ≥ 0x34) : ELF32Header := { 
+def mkELF32Header (bs : ByteArray) (h : bs.size ≥ 0x34) : ELF32Header := {
   e_ident     := NByteArray.extract bs 0x10 (by omega),
   e_type      := getUInt16from 0x10 (by omega),
   e_machine   := getUInt16from 0x12 (by omega),

--- a/ELFSage/Types/File.lean
+++ b/ELFSage/Types/File.lean
@@ -267,3 +267,8 @@ def RawELFFile.sectionHeadersToString (elffile : RawELFFile) := Id.run do
 
   out := out ++ "]"
   return out
+
+def RawELFFile.headersToString (elffile : RawELFFile) :=
+  toString elffile.getRawELFHeader ++ "\n" ++
+  RawELFFile.sectionHeadersToString elffile ++ "\n" ++
+  RawELFFile.programHeadersToString elffile

--- a/ELFSage/Types/File.lean
+++ b/ELFSage/Types/File.lean
@@ -3,6 +3,12 @@ import ELFSage.Types.SectionHeaderTable
 import ELFSage.Types.ProgramHeaderTable
 import ELFSage.Types.Section
 import ELFSage.Types.Segment
+import ELFSage.Util.Flags
+import ELFSage.Util.Hex
+import ELFSage.Util.List
+
+open Hex
+open Flags
 
 def getInhabitedRanges
   [ELFHeader α] (eh : α)
@@ -151,3 +157,113 @@ instance : ELFHeader RawELFFile where
   e_shentsize ef  := ELFHeader.e_shentsize ef.getRawELFHeader
   e_shnum ef      := ELFHeader.e_shnum ef.getRawELFHeader
   e_shstrndx ef   := ELFHeader.e_shstrndx ef.getRawELFHeader
+
+private def getProgramHeaderType (n: Nat) := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 1           => "PT_LOAD"          -- (0x1)
+  | 2           => "PT_DYNAMIC"       -- (0x2)
+  | 3           => "PT_INTERP"        -- (0x3)
+  | 4           => "PT_NOTE"          -- (0x4)
+  | 6           => "PT_PHDR"          -- (0x6)
+  | 1685382480  => "PT_GNU_EH_FRAME"  -- (0x6474E550)
+  | 1685382481  => "PT_GNU_STACK"     -- (0x6474E551)
+  | 1685382482  => "PT_GNU_RELRO"     -- (0x6474E552)
+  | 1685382483  => "PT_GNU_PROPERTY"  -- (0x6474E553)
+  | _ => panic s!"Unrecognized program header type {n}"
+
+private def getProgramHeaderFlag (flagIndex: Nat) := match flagIndex with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 0  => "PF_X"  -- (0x1)
+  | 1  => "PF_W"  -- (0x2)
+  | 2  => "PF_R"  -- (0x4)
+  | _ => panic s!"Unrecognized program header flag {flagIndex}"
+
+private def programHeaderFlagsToString (flags: Nat) (indent: String) : String :=
+  getFlagBits flags 32
+    |> .map (λ flag => s!"{indent}{getProgramHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
+    |> List.insertionSort (. < .) -- sort by flag name
+    |> String.join
+
+def RawELFFile.programHeadersToString (elffile : RawELFFile) := Id.run do
+  let mut out := "ProgramHeaders [\n"
+  let headers := elffile.getRawProgramHeaderTableEntries
+  let mut idx := 0
+  for ⟨phte, _⟩ in headers do
+    let nextHeader :=
+        "  ProgramHeader {\n" ++
+      s!"    Type: {getProgramHeaderType $ ProgramHeaderTableEntry.p_type phte} (0x{toHex $ ProgramHeaderTableEntry.p_type phte})\n" ++
+      s!"    Offset: 0x{toHex $ ProgramHeaderTableEntry.p_offset phte}\n" ++
+      s!"    VirtualAddress: 0x{toHex $ ProgramHeaderTableEntry.p_vaddr phte}\n" ++
+      s!"    PhysicalAddress: 0x{toHex $ ProgramHeaderTableEntry.p_paddr phte}\n" ++
+      s!"    FileSize: {ProgramHeaderTableEntry.p_filesz phte}\n" ++
+      s!"    MemSize: {ProgramHeaderTableEntry.p_memsz phte}\n" ++
+      s!"    Flags [ (0x{toHex $ ProgramHeaderTableEntry.p_flags phte})\n" ++
+      s!"{     programHeaderFlagsToString (ProgramHeaderTableEntry.p_flags phte) "      "}" ++
+        "    ]\n" ++
+      s!"    Alignment: {ProgramHeaderTableEntry.p_align phte}\n" ++
+        "  }\n"
+    out := out ++ nextHeader
+    idx := idx + 1
+
+  out := out ++ "]"
+  return out
+
+private def getSectionHeaderType (n: Nat) := match n with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 0           => "SHT_NULL"         -- (0x0)
+  | 1           => "SHT_PROGBITS"     -- (0x1)
+  | 3           => "SHT_STRTAB"       -- (0x3)
+  | 4           => "SHT_RELA"         -- (0x4)
+  | 6           => "SHT_DYNAMIC"      -- (0x6)
+  | 7           => "SHT_NOTE"         -- (0x7)
+  | 8           => "SHT_NOBITS"       -- (0x8)
+  | 11          => "SHT_DYNSYM"       -- (0xB)
+  | 14          => "SHT_INIT_ARRAY"   -- (0xE)
+  | 15          => "SHT_FINI_ARRAY"   -- (0xF)
+  | 1879048182  => "SHT_GNU_HASH"     -- (0x6FFFFFF6)
+  | 1879048190  => "SHT_GNU_verneed"  -- (0x6FFFFFFE)
+  | 1879048191  => "SHT_GNU_versym"   -- (0x6FFFFFFF)
+  | _ => panic s!"Unrecognized section header type {n}"
+
+private def getSectionHeaderFlag (flagIndex: Nat) := match flagIndex with
+  -- TODO: Finish populating this list of magic numbers, it is incomplete.
+  | 0  => "SHF_WRITE"      -- (0x1)
+  | 1  => "SHF_ALLOC"      -- (0x2)
+  | 2  => "SHF_EXECINSTR"  -- (0x4)
+  | 4  => "SHF_MERGE"      -- (0x10)
+  | 5  => "SHF_STRINGS"    -- (0x20)
+  | _ => panic s!"Unrecognized section header flag {flagIndex}"
+
+private def sectionHeaderFlagsToString (flags: Nat) (indent: String) : String :=
+  getFlagBits flags 64
+    |> .map (λ flag => s!"{indent}{getSectionHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
+    |> List.insertionSort (. < .) -- sort by flag name
+    |> String.join
+
+def RawELFFile.sectionHeadersToString (elffile : RawELFFile) := Id.run do
+  let mut out := "Sections [\n"
+  let headers := elffile.getRawSectionHeaderTableEntries
+  let mut idx := 0
+  for ⟨phte, sec⟩ in headers do
+    let name := match sec.section_name_as_string with | .some s => s | _ => ""
+    let nextHeader :=
+        "  Section {\n" ++
+      s!"    Index: {idx}\n" ++
+      s!"    Name: {name} ({SectionHeaderTableEntry.sh_name phte})\n" ++
+      s!"    Type: {getSectionHeaderType $ SectionHeaderTableEntry.sh_type phte} (0x{toHex $ SectionHeaderTableEntry.sh_type phte})\n" ++
+      s!"    Flags [ (0x{toHex $ SectionHeaderTableEntry.sh_flags phte})\n" ++
+      s!"{     sectionHeaderFlagsToString (SectionHeaderTableEntry.sh_flags phte) "      "}" ++
+        "    ]\n" ++
+      s!"    Address: 0x{toHex $ SectionHeaderTableEntry.sh_addr phte}\n" ++
+      s!"    Offset: 0x{toHex $ SectionHeaderTableEntry.sh_offset phte}\n" ++
+      s!"    Size: {SectionHeaderTableEntry.sh_size phte}\n" ++
+      s!"    Link: {SectionHeaderTableEntry.sh_link phte}\n" ++
+      s!"    Info: {SectionHeaderTableEntry.sh_info phte}\n" ++
+      s!"    AddressAlignment: {SectionHeaderTableEntry.sh_addralign phte}\n" ++
+      s!"    EntrySize: {SectionHeaderTableEntry.sh_entsize phte}\n" ++
+        "  }\n"
+    out := out ++ nextHeader
+    idx := idx + 1
+
+  out := out ++ "]"
+  return out

--- a/ELFSage/Types/File.lean
+++ b/ELFSage/Types/File.lean
@@ -181,7 +181,7 @@ private def getProgramHeaderFlag (flagIndex: Nat) := match flagIndex with
 private def programHeaderFlagsToString (flags: Nat) (indent: String) : String :=
   getFlagBits flags 32
     |> .map (λ flag => s!"{indent}{getProgramHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
-    |> List.insertionSort (. < .) -- sort by flag name
+    |> (λ a => .insertionSort a (. < .)) -- sort by flag name
     |> String.join
 
 def RawELFFile.programHeadersToString (elffile : RawELFFile) := Id.run do
@@ -237,7 +237,7 @@ private def getSectionHeaderFlag (flagIndex: Nat) := match flagIndex with
 private def sectionHeaderFlagsToString (flags: Nat) (indent: String) : String :=
   getFlagBits flags 64
     |> .map (λ flag => s!"{indent}{getSectionHeaderFlag flag} (0x{toHex (1 <<< flag)})\n")
-    |> List.insertionSort (. < .) -- sort by flag name
+    |> (λ a => .insertionSort a (. < .)) -- sort by flag name
     |> String.join
 
 def RawELFFile.sectionHeadersToString (elffile : RawELFFile) := Id.run do

--- a/ELFSage/Types/ProgramHeaderTable.lean
+++ b/ELFSage/Types/ProgramHeaderTable.lean
@@ -49,13 +49,13 @@ instance : ProgramHeaderTableEntry ELF64ProgramHeaderTableEntry where
   p_memsz ph  := ph.p_memsz.toNat
   p_align ph  := ph.p_align.toNat
 
-def mkELF64ProgramHeaderTableEntry 
+def mkELF64ProgramHeaderTableEntry
   (isBigEndian : Bool)
   (bs : ByteArray)
   (offset : Nat)
   (h : bs.size - offset ≥ 0x38) :
   ELF64ProgramHeaderTableEntry := {
-    p_type   := getUInt32from (offset + 0x00) (by omega), 
+    p_type   := getUInt32from (offset + 0x00) (by omega),
     p_flags  := getUInt32from (offset + 0x04) (by omega),
     p_offset := getUInt64from (offset + 0x08) (by omega),
     p_vaddr  := getUInt64from (offset + 0x10) (by omega),
@@ -71,7 +71,7 @@ def mkELF64ProgramHeaderTableEntry
 def mkELF64ProgramHeaderTableEntry?
   (isBigEndian : Bool)
   (bs : ByteArray)
-  (offset : Nat) 
+  (offset : Nat)
   : Except String ELF64ProgramHeaderTableEntry :=
   if h : bs.size - offset ≥ 0x38
   then .ok $ mkELF64ProgramHeaderTableEntry isBigEndian bs offset h
@@ -81,9 +81,9 @@ def mkELF64ProgramHeaderTableEntry?
 def ELF64Header.mkELF64ProgramHeaderTable?
   (eh : ELF64Header)
   (bytes : ByteArray)
-  : Except String (List ELF64ProgramHeaderTableEntry):= 
+  : Except String (List ELF64ProgramHeaderTableEntry):=
   let isBigendian := ELFHeader.isBigendian eh
-  List.mapM 
+  List.mapM
     (λoffset ↦ mkELF64ProgramHeaderTableEntry? isBigendian bytes offset)
     (ELFHeader.getProgramHeaderOffsets eh)
 
@@ -116,13 +116,13 @@ instance : ProgramHeaderTableEntry ELF32ProgramHeaderTableEntry where
   p_memsz ph  := ph.p_memsz.toNat
   p_align ph  := ph.p_align.toNat
 
-def mkELF32ProgramHeaderTableEntry 
+def mkELF32ProgramHeaderTableEntry
   (isBigEndian : Bool)
   (bs : ByteArray)
   (offset : Nat)
   (h : bs.size - offset ≥ 0x20) :
   ELF32ProgramHeaderTableEntry := {
-    p_type   := getUInt32from (offset + 0x00) (by omega), 
+    p_type   := getUInt32from (offset + 0x00) (by omega),
     p_offset := getUInt32from (offset + 0x04) (by omega),
     p_vaddr  := getUInt32from (offset + 0x08) (by omega),
     p_paddr  := getUInt32from (offset + 0x0C) (by omega),
@@ -137,9 +137,9 @@ def mkELF32ProgramHeaderTableEntry
 def mkELF32ProgramHeaderTableEntry?
   (isBigEndian : Bool)
   (bs : ByteArray)
-  (offset : Nat) 
+  (offset : Nat)
   : Except String ELF32ProgramHeaderTableEntry :=
-  if h : bs.size - offset ≥ 0x20 
+  if h : bs.size - offset ≥ 0x20
   then .ok $ mkELF32ProgramHeaderTableEntry isBigEndian bs offset h
   else .error $ "Program header table entry offset {offset} doesn't leave enough space for the entry, " ++
                 "which requires 0x20 bytes."
@@ -147,10 +147,10 @@ def mkELF32ProgramHeaderTableEntry?
 def ELF32Header.mkELF32ProgramHeaderTable?
   (eh : ELF32Header)
   (bytes : ByteArray)
-  : Except String (List ELF32ProgramHeaderTableEntry):= 
+  : Except String (List ELF32ProgramHeaderTableEntry):=
   let isBigendian := ELFHeader.isBigendian eh
-  List.mapM 
-    (λoffset ↦ mkELF32ProgramHeaderTableEntry? isBigendian bytes offset) 
+  List.mapM
+    (λoffset ↦ mkELF32ProgramHeaderTableEntry? isBigendian bytes offset)
     (ELFHeader.getProgramHeaderOffsets eh)
 
 inductive RawProgramHeaderTableEntry where
@@ -159,21 +159,21 @@ inductive RawProgramHeaderTableEntry where
   deriving Repr
 
 instance : ProgramHeaderTableEntry RawProgramHeaderTableEntry where
-  p_type ph   := match ph with | .elf32 ph => ph.p_type.toNat   | .elf64 ph => ph.p_type.toNat   
-  p_flags ph  := match ph with | .elf32 ph => ph.p_flags.toNat  | .elf64 ph => ph.p_flags.toNat  
-  p_offset ph := match ph with | .elf32 ph => ph.p_offset.toNat | .elf64 ph => ph.p_offset.toNat 
-  p_vaddr ph  := match ph with | .elf32 ph => ph.p_vaddr.toNat  | .elf64 ph => ph.p_vaddr.toNat  
-  p_paddr ph  := match ph with | .elf32 ph => ph.p_paddr.toNat  | .elf64 ph => ph.p_paddr.toNat  
-  p_filesz ph := match ph with | .elf32 ph => ph.p_filesz.toNat | .elf64 ph => ph.p_filesz.toNat 
-  p_memsz ph  := match ph with | .elf32 ph => ph.p_memsz.toNat  | .elf64 ph => ph.p_memsz.toNat  
-  p_align ph  := match ph with | .elf32 ph => ph.p_align.toNat  | .elf64 ph => ph.p_align.toNat  
+  p_type ph   := match ph with | .elf32 ph => ph.p_type.toNat   | .elf64 ph => ph.p_type.toNat
+  p_flags ph  := match ph with | .elf32 ph => ph.p_flags.toNat  | .elf64 ph => ph.p_flags.toNat
+  p_offset ph := match ph with | .elf32 ph => ph.p_offset.toNat | .elf64 ph => ph.p_offset.toNat
+  p_vaddr ph  := match ph with | .elf32 ph => ph.p_vaddr.toNat  | .elf64 ph => ph.p_vaddr.toNat
+  p_paddr ph  := match ph with | .elf32 ph => ph.p_paddr.toNat  | .elf64 ph => ph.p_paddr.toNat
+  p_filesz ph := match ph with | .elf32 ph => ph.p_filesz.toNat | .elf64 ph => ph.p_filesz.toNat
+  p_memsz ph  := match ph with | .elf32 ph => ph.p_memsz.toNat  | .elf64 ph => ph.p_memsz.toNat
+  p_align ph  := match ph with | .elf32 ph => ph.p_align.toNat  | .elf64 ph => ph.p_align.toNat
 
 def mkRawProgramHeaderTableEntry?
   (bs : ByteArray)
   (is64Bit : Bool)
   (isBigendian : Bool)
   (offset : Nat)
-  : Except String RawProgramHeaderTableEntry := 
+  : Except String RawProgramHeaderTableEntry :=
   match is64Bit with
   | true  => .elf64 <$> mkELF64ProgramHeaderTableEntry? isBigendian bs offset
   | false => .elf32 <$> mkELF32ProgramHeaderTableEntry? isBigendian bs offset
@@ -182,15 +182,15 @@ inductive RawProgramHeaderTable where
   | elf32 : List ELF32ProgramHeaderTableEntry → RawProgramHeaderTable
   | elf64 : List ELF64ProgramHeaderTableEntry → RawProgramHeaderTable
 
-def RawProgramHeaderTable.length : RawProgramHeaderTable → Nat 
+def RawProgramHeaderTable.length : RawProgramHeaderTable → Nat
   | elf32 pht => pht.length
   | elf64 pht => pht.length
 
-def ELFHeader.mkRawProgramHeaderTable? 
+def ELFHeader.mkRawProgramHeaderTable?
   [ELFHeader α]
   (eh : α)
   (bytes : ByteArray)
-  : Except String RawProgramHeaderTable := 
+  : Except String RawProgramHeaderTable :=
   let shoffsets := (List.range (ELFHeader.e_phnum eh)).map λidx ↦ ELFHeader.e_phoff eh + ELFHeader.e_phentsize eh * idx
   let isBigendian := ELFHeader.isBigendian eh
   let is64Bit := ELFHeader.is64Bit eh

--- a/ELFSage/Util/Flags.lean
+++ b/ELFSage/Util/Flags.lean
@@ -1,0 +1,10 @@
+namespace Flags
+
+/--
+Get the list of indices that match the set bits in a bitvector of length `numBits`.
+The bitvector is represented as a Nat. The indices are zero-indexed.
+-/
+def getFlagBits (flags: Nat) (numBits: Nat) : List Nat :=
+  (List.range numBits).filter (λ n => flags.testBit n)
+
+end Flags

--- a/ELFSage/Util/Hex.lean
+++ b/ELFSage/Util/Hex.lean
@@ -1,0 +1,9 @@
+import ELFSage.Util.String
+
+namespace Hex
+
+def toHex (n: Nat) := String.toUpper $ String.mk $ Nat.toDigits 16 n
+
+def toHexMinLength (n: Nat) (minChars: Nat) := (toHex n).leftpad minChars '0'
+
+end Hex

--- a/ELFSage/Util/List.lean
+++ b/ELFSage/Util/List.lean
@@ -1,0 +1,11 @@
+namespace List
+
+-- from Std
+
+/--
+Pads `l : List α` with repeated occurrences of `a : α` until it is of length `n`.
+If `l` is initially larger than `n`, just return `l`.
+-/
+def leftpad (n : Nat) (a : α) (l : List α) : List α := replicate (n - length l) a ++ l
+
+end List

--- a/ELFSage/Util/List.lean
+++ b/ELFSage/Util/List.lean
@@ -8,29 +8,13 @@ If `l` is initially larger than `n`, just return `l`.
 -/
 def leftpad (n : Nat) (a : α) (l : List α) : List α := replicate (n - length l) a ++ l
 
--- from Mathlib
 
-section sort
+-- homegrown
 
-variable {α : Type uu} (r : α → α → Prop) [DecidableRel r]
-local infixl:50 " ≼ " => r
-
-section InsertionSort
-
-/-- `orderedInsert a l` inserts `a` into `l` at such that
-  `orderedInsert a l` is sorted if `l` is. -/
-@[simp]
-def orderedInsert (a : α) : List α → List α
-  | [] => [a]
-  | b :: l => if a ≼ b then a :: b :: l else b :: orderedInsert a l
-
-/-- `insertionSort l` returns `l` sorted using the insertion sort algorithm. -/
-@[simp]
-def insertionSort : List α → List α
-  | [] => []
-  | b :: l => orderedInsert r b (insertionSort l)
-
-end InsertionSort
-end sort
+/--
+Wrapper for Array.insertionSort.
+-/
+def insertionSort (a : List α) (lt : α → α → Bool) : List α :=
+  (a.toArray.insertionSort lt).toList
 
 end List

--- a/ELFSage/Util/List.lean
+++ b/ELFSage/Util/List.lean
@@ -8,4 +8,29 @@ If `l` is initially larger than `n`, just return `l`.
 -/
 def leftpad (n : Nat) (a : α) (l : List α) : List α := replicate (n - length l) a ++ l
 
+-- from Mathlib
+
+section sort
+
+variable {α : Type uu} (r : α → α → Prop) [DecidableRel r]
+local infixl:50 " ≼ " => r
+
+section InsertionSort
+
+/-- `orderedInsert a l` inserts `a` into `l` at such that
+  `orderedInsert a l` is sorted if `l` is. -/
+@[simp]
+def orderedInsert (a : α) : List α → List α
+  | [] => [a]
+  | b :: l => if a ≼ b then a :: b :: l else b :: orderedInsert a l
+
+/-- `insertionSort l` returns `l` sorted using the insertion sort algorithm. -/
+@[simp]
+def insertionSort : List α → List α
+  | [] => []
+  | b :: l => orderedInsert r b (insertionSort l)
+
+end InsertionSort
+end sort
+
 end List

--- a/ELFSage/Util/String.lean
+++ b/ELFSage/Util/String.lean
@@ -1,0 +1,12 @@
+import ELFSage.Util.List
+
+namespace String
+
+-- from Mathlib
+
+/-- Pad `s : String` with repeated occurrences of `c : Char` until it's of length `n`.
+  If `s` is initially larger than `n`, just return `s`. -/
+def leftpad (n : Nat) (c : Char) (s : String) : String :=
+  ⟨List.leftpad n c s.data⟩
+
+end String


### PR DESCRIPTION
For magic numbers that get decoded to strings, the pretty-printed output only supports the magic numbers that appear in the /bin/true example.