### PR TITLE
Bump toolchain

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,14 +1,15 @@
-{"version": 7,
+{"version": "1.1.0",
  "packagesDir": ".lake/packages",
  "packages":
  [{"url": "https://github.com/leanprover/lean4-cli.git",
    "type": "git",
    "subDir": null,
-   "rev": "be8fa79a28b8b6897dce0713ef50e89c4a0f6ef5",
+   "scope": "",
+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
    "name": "Cli",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",
    "inherited": false,
-   "configFile": "lakefile.lean"}],
+   "configFile": "lakefile.toml"}],
  "name": "ELFSage",
  "lakeDir": ".lake"}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-03-08
+leanprover/lean4:nightly-2024-07-12


### PR DESCRIPTION
Update Lean toolchain to a recent nightly release (`nightly-2024-07-12`) and fix resulting build failures.

### Build Tests

`lake build` succeeds with the following warning for the skipped theorem `UInt64.shiftUnshift` (also skipped in the current `main` branch): 
`././././ELFSage/Util/ByteArray.lean:560:8: declaration uses 'sorry'`

`lake exec test` returns `PASS`.