### PR TITLE
chore: Use less call stack for findSymbolTableEntryInSection.

### DIFF
--- a/ELFSage/Types/Symbol.lean
+++ b/ELFSage/Types/Symbol.lean
@@ -126,7 +126,7 @@ def RawELFFile.findSymbolTableEntryInSection
   else do
     let (str, ste) ← getSymbolTableEntryInSection elffile shte sec symidx
     if str == symname then return ste
-    findSymbolTableEntryInSection elffile (symidx + 1) maxidx shte sec symname
+    else findSymbolTableEntryInSection elffile (symidx + 1) maxidx shte sec symname
   termination_by (maxidx - symidx)
 
 /- Get the `st_value` of the symbol `symbolname` and its contents


### PR DESCRIPTION
In investigating a failing CI build over at LNSym (https://github.com/leanprover/LNSym/pull/59), we noticed that bumping up the version of ELFSage lead to a build running out of stack space: https://github.com/leanprover/LNSym/actions/runs/10256261530/job/28374978565#step:6:454

```
deep recursion was detected at 'interpreter' (potential solution: increase stack space in your system)
interpreter stacktrace:
...
```

On reading the IR, we notice that we generate an extra closure `._lambda_1`, which is eliminated by changing the code to contain an `else` branch.